### PR TITLE
chore: upgrade cids dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "bs58": "4.0.1",
-    "cids": "0.5.3",
+    "cids": "0.5.4",
     "multibase": "0.4.0",
     "multihashes": "0.4.13"
   },


### PR DESCRIPTION
Please can we have a quick review, merge and release as this is breaking all js-ipfs installs atm?

cids@0.5.4 now uses class-is and checks for CIDs are now failing because is-ipfs is using the old version.