### PR TITLE
 fix: toV0 and toV1 create instances that cause isCID be false 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="0.4.7"></a>
+## [0.4.7](https://github.com/ipfs/is-ipfs/compare/v0.4.6...v0.4.7) (2018-09-25)
+
+
+### Bug Fixes
+
+* switch to cids v0.5.5 ([c07a35f](https://github.com/ipfs/is-ipfs/commit/c07a35f))
+
+
+
 <a name="0.4.6"></a>
 ## [0.4.6](https://github.com/ipfs/is-ipfs/compare/v0.4.5...v0.4.6) (2018-09-25)
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "is-ipfs",
   "version": "0.4.6",
   "description": "A set of utilities to help identify IPFS resources",
+  "leadMaintainer": "Marcin Rataj <lidel@lidel.org>",
   "main": "src/index.js",
   "browser": {
     "fs": false
@@ -30,9 +31,9 @@
   "license": "MIT",
   "dependencies": {
     "bs58": "4.0.1",
-    "cids": "0.5.4",
-    "multibase": "0.4.0",
-    "multihashes": "0.4.13"
+    "cids": "~0.5.5",
+    "multibase": "~0.4.0",
+    "multihashes": "~0.4.13"
   },
   "devDependencies": {
     "aegir": "15.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-ipfs",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "A set of utilities to help identify IPFS resources",
   "leadMaintainer": "Marcin Rataj <lidel@lidel.org>",
   "main": "src/index.js",


### PR DESCRIPTION
Context: https://github.com/ipld/js-cid/commit/14ab8e4

(already at npm as v0.4.7)