### PR TITLE
feat: add cidPath function

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ isIPFS.ipfsPath('/ipfs/invalid-hash') // false
 isIPFS.ipnsPath('/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // false
 isIPFS.ipnsPath('/ipns/github.com') // true
 
+isIPFS.cidPath('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o/path/to/file') // true
+isIPFS.cidPath('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o/') // true
+isIPFS.cidPath('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // false
+isIPFS.cidPath('/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // false
+isIPFS.cidPath('/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o/file') // false
+
 isIPFS.subdomain('http://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.dweb.link') // true
 isIPFS.subdomain('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link') // true
 isIPFS.subdomain('http://www.bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.dweb.link') // false

--- a/src/index.js
+++ b/src/index.js
@@ -94,12 +94,16 @@ function isIpns (input, pattern, protocolMatch = defaultProtocolMatch, hashMatch
   return true
 }
 
+function isString (input) {
+  return typeof input === 'string'
+}
+
 function convertToString (input) {
   if (Buffer.isBuffer(input)) {
     return base58.encode(input)
   }
 
-  if (typeof input === 'string') {
+  if (isString(input)) {
     return input
   }
 
@@ -125,5 +129,6 @@ module.exports = {
   ipnsPath: (path) => isIpns(path, pathPattern),
   path: (path) => (isIpfs(path, pathPattern) || isIpns(path, pathPattern)),
   pathPattern: pathPattern,
-  urlOrPath: (x) => (isIpfs(x, urlPattern) || isIpns(x, urlPattern) || isIpfs(x, pathPattern) || isIpns(x, pathPattern))
+  urlOrPath: (x) => (isIpfs(x, urlPattern) || isIpns(x, urlPattern) || isIpfs(x, pathPattern) || isIpns(x, pathPattern)),
+  cidPath: path => isString(path) && path.includes('/') && isCID(path.split('/')[0])
 }

--- a/src/index.js
+++ b/src/index.js
@@ -130,5 +130,5 @@ module.exports = {
   path: (path) => (isIpfs(path, pathPattern) || isIpns(path, pathPattern)),
   pathPattern: pathPattern,
   urlOrPath: (x) => (isIpfs(x, urlPattern) || isIpns(x, urlPattern) || isIpfs(x, pathPattern) || isIpns(x, pathPattern)),
-  cidPath: path => isString(path) && path.includes('/') && isCID(path.split('/')[0])
+  cidPath: path => isString(path) && !isCID(path) && isIpfs(`/ipfs/${path}`, pathPattern)
 }

--- a/test/test-path.spec.js
+++ b/test/test-path.spec.js
@@ -131,4 +131,24 @@ describe('ipfs path', () => {
     expect(actual).to.equal(false)
     done()
   })
+
+  it('isIPFS.cidPath should not match a CID path', () => {
+    const actual = isIPFS.cidPath('QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm/path/to/file')
+    expect(actual).to.equal(true)
+  })
+
+  it('isIPFS.cidPath should not match a CID path with trailing slash', () => {
+    const actual = isIPFS.cidPath('QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm/')
+    expect(actual).to.equal(true)
+  })
+
+  it('isIPFS.cidPath should not match a CID', () => {
+    const actual = isIPFS.cidPath('QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm')
+    expect(actual).to.equal(false)
+  })
+
+  it('isIPFS.cidPath should not match a non string', () => {
+    const actual = isIPFS.cidPath({ toString: () => 'QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm/path/to/file' })
+    expect(actual).to.equal(false)
+  })
 })

--- a/test/test-path.spec.js
+++ b/test/test-path.spec.js
@@ -132,12 +132,12 @@ describe('ipfs path', () => {
     done()
   })
 
-  it('isIPFS.cidPath should not match a CID path', () => {
+  it('isIPFS.cidPath should match a CID path', () => {
     const actual = isIPFS.cidPath('QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm/path/to/file')
     expect(actual).to.equal(true)
   })
 
-  it('isIPFS.cidPath should not match a CID path with trailing slash', () => {
+  it('isIPFS.cidPath should match a CID path with trailing slash', () => {
     const actual = isIPFS.cidPath('QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm/')
     expect(actual).to.equal(true)
   })
@@ -149,6 +149,11 @@ describe('ipfs path', () => {
 
   it('isIPFS.cidPath should not match a non string', () => {
     const actual = isIPFS.cidPath({ toString: () => 'QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm/path/to/file' })
+    expect(actual).to.equal(false)
+  })
+
+  it('isIPFS.cidPath should not match an IPFS path', () => {
+    const actual = isIPFS.cidPath('/ipfs/QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm')
     expect(actual).to.equal(false)
   })
 })


### PR DESCRIPTION
In the IPFS API (e.g. [`ipfs.cat`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/FILES.md#cat), [`ipfs.dag.get`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/DAG.md#dagget)) we allow passing of paths like `QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm/path/to/file`, and infer a `/ipfs` prefix. This PR adds a method to validate whether the passed input is a path like this.