### PR TITLE
fix: double validate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,8 @@ function isMultibase (hash) {
 
 function isCID (hash) {
   try {
-    return CID.isCID(new CID(hash))
+    new CID(hash) // eslint-disable-line no-new
+    return true
   } catch (e) {
     return false
   }


### PR DESCRIPTION
We don't need to check a CID is a CID immediately after it's created 😉.