### PR TITLE
chore: update cids dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ isIPFS.multihash('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // true
 isIPFS.multihash('noop') // false
 
 isIPFS.cid('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // true (CIDv0)
-isIPFS.cid('zdj7WWeQ43G6JJvLWQWZpyHuAMq6uYWRjkBXFad11vE2LHhQ7') // true (CIDv1)
+isIPFS.cid('bafybeiasb5vpmaounyilfuxbd3lryvosl4yefqrfahsb2esg46q6tu6y5q') // true (CIDv1 in Base32)
+isIPFS.cid('zdj7WWeQ43G6JJvLWQWZpyHuAMq6uYWRjkBXFad11vE2LHhQ7') // true (CIDv1 in Base58btc)
 isIPFS.cid('noop') // false
 
 isIPFS.base32cid('bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va') // true

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "license": "MIT",
   "dependencies": {
     "bs58": "^4.0.1",
-    "cids": "~0.5.6",
-    "mafmt": "^v6.0.7",
+    "cids": "~0.7.0",
+    "mafmt": "^6.0.7",
     "multiaddr": "^6.0.4",
     "multibase": "~0.6.0",
     "multihashes": "~0.4.13"

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -38,7 +38,7 @@ describe('ipfs cid', () => {
     done()
   })
 
-  it('isIPFS.cid should match a valid CIDv1', (done) => {
+  it('isIPFS.cid should match a valid CIDv1 in Base58btc', (done) => {
     const actual = isIPFS.cid('zdj7WWeQ43G6JJvLWQWZpyHuAMq6uYWRjkBXFad11vE2LHhQ7')
     expect(actual).to.equal(true)
     done()


### PR DESCRIPTION
Note that since this module does not return CIDs, this change could be released as a patch version.