### PR TITLE
feat: support subdomains in isIPFS.url(url)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ node_modules
 
 dist
 lib
+docs

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install --save is-ipfs
 The code published to npm that gets loaded on require is in fact an ES5 transpiled version with the right shims added. This means that you can require it and use with your favorite bundler without having to adjust asset management process.
 
 ```js
-var isIPFS = require('is-ipfs')
+const isIPFS = require('is-ipfs')
 ```
 
 
@@ -98,6 +98,9 @@ isIPFS.ipnsSubdomain('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j5
 isIPFS.ipnsSubdomain('http://QmcNioXSC1bfJj1dcFErhUfyjFzoX2HodkRccsFFVJJvg8.ipns.dweb.link') // false
 isIPFS.ipnsSubdomain('http://foo-bar.ipns.dweb.link') // false (not a PeerID)
 
+isIPFS.dnslinkSubdomain('http://en.wikipedia-on-ipfs.org.ipns.localhost:8080') // true
+isIPFS.dnslinkSubdomain('http//bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link') // false
+
 isIPFS.multiaddr('/ip4/127.0.0.1/udp/1234') // true
 isIPFS.multiaddr('/ip4/127.0.0.1/udp/1234/http') // true
 isIPFS.multiaddr('/ip6/::1/udp/1234') // true
@@ -116,7 +119,7 @@ A suite of util methods that provides efficient validation.
 
 Detection of IPFS Paths and identifiers in URLs is a two-stage process:
 1.  `urlPattern`/`pathPattern`/`subdomainPattern` regex is applied to quickly identify potential candidates
-2.  proper CID validation is applied to remove false-positives
+2.  proper CID/FQDN validation is applied to remove false-positives
 
 
 ## Content Identifiers
@@ -178,15 +181,19 @@ Validated subdomain convention: `cidv1b32.ip(f|n)s.domain.tld`
 
 ### `isIPFS.subdomain(url)`
 
-Returns `true` if the provided string includes a valid IPFS or IPNS subdomain or `false` otherwise.
+Returns `true` if the provided `url` string includes a valid IPFS, IPNS or DNSLink subdomain or `false` otherwise.
 
 ### `isIPFS.ipfsSubdomain(url)`
 
-Returns `true` if the provided string includes a valid IPFS subdomain or `false` otherwise.
+Returns `true` if the provided `url` string includes a valid IPFS subdomain (case-insensitive CIDv1) or `false` otherwise.
 
 ### `isIPFS.ipnsSubdomain(url)`
 
-Returns `true` if the provided string includes a valid IPNS subdomain or `false` otherwise.
+Returns `true` if the provided `url` string includes a valid IPNS subdomain (CIDv1 with `libp2p-key` multicodec) or `false` otherwise.
+
+### `isIPFS.dnslinkSubdomain(url)`
+
+Returns `true` if the provided `url` string includes a valid DNSLink subdomain (such as `http://en.wikipedia-on-ipfs.org.ipns.localhost:8080`) or `false` otherwise.
 
 ## Multiaddrs
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,8 @@ isIPFS.ipfsSubdomain('http://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27
 isIPFS.ipnsSubdomain('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link') // true
 isIPFS.ipnsSubdomain('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.dweb.link') // false
 isIPFS.ipnsSubdomain('http://QmcNioXSC1bfJj1dcFErhUfyjFzoX2HodkRccsFFVJJvg8.ipns.dweb.link') // false
-isIPFS.ipnsSubdomain('http://foo-bar.ipns.dweb.link') // false (not a PeerID)
-
-isIPFS.dnslinkSubdomain('http://en.wikipedia-on-ipfs.org.ipns.localhost:8080') // true
-isIPFS.dnslinkSubdomain('http//bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link') // false
-isIPFS.dnslinkSubdomain('http//hostname-without-tld.ipns.dweb.link') // false
+isIPFS.ipnsSubdomain('http://en.wikipedia-on-ipfs.org.ipns.localhost:8080') // true (assuming DNSLink)
+isIPFS.ipnsSubdomain('http://hostname-without-tld.ipns.dweb.link') // false (missing TLD)
 
 isIPFS.multiaddr('/ip4/127.0.0.1/udp/1234') // true
 isIPFS.multiaddr('/ip4/127.0.0.1/udp/1234/http') // true
@@ -187,7 +184,7 @@ Validated subdomain convention: `cidv1b32.ip(f|n)s.domain.tld`
 
 ### `isIPFS.subdomain(url)`
 
-Returns `true` if the provided `url` string includes a valid IPFS, looks like IPNS or DNSLink subdomain or `false` otherwise.
+Returns `true` if the provided `url` string includes a valid IPFS, looks like IPNS/DNSLink subdomain or `false` otherwise.
 
 ### `isIPFS.ipfsSubdomain(url)`
 
@@ -196,23 +193,16 @@ Returns `true` if the provided `url` string includes a valid IPFS subdomain (cas
 ### `isIPFS.ipnsSubdomain(url)`
 
 Returns `true` if the provided `url` string looks like a valid IPNS subdomain
-(subdomain context requires CIDv1 with `libp2p-key` multicodec) or `false`
+(CIDv1 with `libp2p-key` multicodec or something that looks like a FQDN, for example `en.wikipedia-on-ipfs.org.ipns.localhost:8080`) or `false`
 otherwise.
 
 **Note:** `ipnsSubdomain` method works in offline mode: it does not perform
 actual IPNS record lookup over DHT or other content routing method. It may
-return false-positives. To ensure IPNS record  exists, make a call to
-`/api/v0/name/resolve?arg=<ipnsid>`
+return false-positives:
 
-### `isIPFS.dnslinkSubdomain(url)`
+- To ensure IPNS record  exists, make a call to `/api/v0/name/resolve?arg=<ipnsid>`
+- To ensure DNSLink exists, make a call to `/api/v0/dns?arg=<fqdn>`
 
-Returns `true` if the provided `url` string looks like a valid DNSLink
-subdomain (such as `http://en.wikipedia-on-ipfs.org.ipns.localhost:8080`) or
-`false` otherwise.
-
-**Note:** `dnslinkSubdomain` method works in offline mode: it does not perform
-actual DNSLink lookup. It may return false-positives. To ensure DNSLink exists,
-make a call to `/api/v0/dns?arg=<fqdn>`
 
 ## Multiaddrs
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ isIPFS.ipnsSubdomain('http://foo-bar.ipns.dweb.link') // false (not a PeerID)
 
 isIPFS.dnslinkSubdomain('http://en.wikipedia-on-ipfs.org.ipns.localhost:8080') // true
 isIPFS.dnslinkSubdomain('http//bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link') // false
+isIPFS.dnslinkSubdomain('http//hostname-without-tld.ipns.dweb.link') // false
 
 isIPFS.multiaddr('/ip4/127.0.0.1/udp/1234') // true
 isIPFS.multiaddr('/ip4/127.0.0.1/udp/1234/http') // true
@@ -186,7 +187,7 @@ Validated subdomain convention: `cidv1b32.ip(f|n)s.domain.tld`
 
 ### `isIPFS.subdomain(url)`
 
-Returns `true` if the provided `url` string includes a valid IPFS, IPNS or DNSLink subdomain or `false` otherwise.
+Returns `true` if the provided `url` string includes a valid IPFS, looks like IPNS or DNSLink subdomain or `false` otherwise.
 
 ### `isIPFS.ipfsSubdomain(url)`
 
@@ -194,11 +195,24 @@ Returns `true` if the provided `url` string includes a valid IPFS subdomain (cas
 
 ### `isIPFS.ipnsSubdomain(url)`
 
-Returns `true` if the provided `url` string includes a valid IPNS subdomain (CIDv1 with `libp2p-key` multicodec) or `false` otherwise.
+Returns `true` if the provided `url` string looks like a valid IPNS subdomain
+(subdomain context requires CIDv1 with `libp2p-key` multicodec) or `false`
+otherwise.
+
+**Note:** `ipnsSubdomain` method works in offline mode: it does not perform
+actual IPNS record lookup over DHT or other content routing method. It may
+return false-positives. To ensure IPNS record  exists, make a call to
+`/api/v0/name/resolve?arg=<ipnsid>`
 
 ### `isIPFS.dnslinkSubdomain(url)`
 
-Returns `true` if the provided `url` string includes a valid DNSLink subdomain (such as `http://en.wikipedia-on-ipfs.org.ipns.localhost:8080`) or `false` otherwise.
+Returns `true` if the provided `url` string looks like a valid DNSLink
+subdomain (such as `http://en.wikipedia-on-ipfs.org.ipns.localhost:8080`) or
+`false` otherwise.
+
+**Note:** `dnslinkSubdomain` method works in offline mode: it does not perform
+actual DNSLink lookup. It may return false-positives. To ensure DNSLink exists,
+make a call to `/api/v0/dns?arg=<fqdn>`
 
 ## Multiaddrs
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ isIPFS.base32cid('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // false
 isIPFS.url('https://ipfs.io/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // true
 isIPFS.url('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?filename=guardian.jpg') // true
 isIPFS.url('https://ipfs.io/ipns/github.com') // true
+isIPFS.url('https://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.dweb.link') // true
+isIPFS.url('http://en.wikipedia-on-ipfs.org.ipfs.localhost:8080') // true
 isIPFS.url('https://github.com/ipfs/js-ipfs/blob/master/README.md') // false
 isIPFS.url('https://google.com') // false
-isIPFS.url('http://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.dweb.link') // false (use .subdomain instead)
-isIPFS.url('http://en.wikipedia-on-ipfs.org.ipfs.localhost:8080') // false (use .subdomain instead)
 
 isIPFS.path('/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // true
 isIPFS.path('/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?filename=guardian.jpg') // true
@@ -69,6 +69,7 @@ isIPFS.urlOrPath('https://ipfs.io/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFo
 isIPFS.urlOrPath('https://ipfs.io/ipns/github.com') // true
 isIPFS.urlOrPath('/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // true
 isIPFS.urlOrPath('/ipns/github.com') // true
+isIPFS.urlOrPath('https://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.dweb.link') // true
 isIPFS.urlOrPath('https://google.com') // false
 
 isIPFS.ipfsUrl('https://ipfs.io/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // true
@@ -124,9 +125,8 @@ isIPFS.peerMultiaddr('/ip4/127.0.0.1/udp/1234') // false
 A suite of util methods that provides efficient validation.
 
 Detection of IPFS Paths and identifiers in URLs is a two-stage process:
-1.  `urlPattern`/`pathPattern`/`subdomainPattern` regex is applied to quickly identify potential candidates
-2.  proper CID/FQDN validation is applied to remove false-positives
-
+1.  `pathPattern`/`pathGatewayPattern`/`subdomainGatewayPattern` regex is applied to quickly identify potential candidates
+2.  proper CID validation is applied to remove false-positives
 
 ## Content Identifiers
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ isIPFS.url('https://github.com/ipfs/js-ipfs/blob/master/README.md') // false
 isIPFS.url('https://google.com') // false
 
 isIPFS.path('/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // true
-isIPFS.path('/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?filename=guardian.jpg') // true
+isIPFS.path('/ipfs/QmbcBPAwCDxRMB1Qe7CRQmxdrTSkxKwM9y6rZw2FjGtbsb/?weird-filename=test.jpg') // true
 isIPFS.path('/ipns/github.com') // true
 isIPFS.path('/ipfs/js-ipfs/blob/master/README.md') // false
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ isIPFS.url('https://ipfs.io/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o'
 isIPFS.url('https://ipfs.io/ipns/github.com') // true
 isIPFS.url('https://github.com/ipfs/js-ipfs/blob/master/README.md') // false
 isIPFS.url('https://google.com') // false
+isIPFS.url('http://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.dweb.link') // false (use .subdomain instead)
+isIPFS.url('http://en.wikipedia-on-ipfs.org.ipfs.localhost:8080') // false (use .subdomain instead)
 
 isIPFS.path('/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // true
 isIPFS.path('/ipns/github.com') // true
@@ -107,9 +109,10 @@ isIPFS.multiaddr('/ip6/::1/udp/1234') // true
 isIPFS.multiaddr('ip6/::1/udp/1234') // false
 isIPFS.multiaddr('/yoloinvalid/::1/udp/1234') // false
 
-isIPFS.peerMultiaddr('/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4') // true
-isIPFS.peerMultiaddr('/ip4/127.0.0.1/tcp/1234/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj') // true
-isIPFS.peerMultiaddr('/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj') // true
+isIPFS.peerMultiaddr('/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4') // true
+isIPFS.peerMultiaddr('/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4') // true (legacy notation)
+isIPFS.peerMultiaddr('/ip4/127.0.0.1/tcp/1234/ws/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj') // true
+isIPFS.peerMultiaddr('/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj') // true
 isIPFS.peerMultiaddr('/ip4/127.0.0.1/udp/1234') // false
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ isIPFS.base32cid('bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va') 
 isIPFS.base32cid('QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // false
 
 isIPFS.url('https://ipfs.io/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // true
+isIPFS.url('https://ipfs.io/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?filename=guardian.jpg') // true
 isIPFS.url('https://ipfs.io/ipns/github.com') // true
 isIPFS.url('https://github.com/ipfs/js-ipfs/blob/master/README.md') // false
 isIPFS.url('https://google.com') // false
@@ -60,6 +61,7 @@ isIPFS.url('http://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.i
 isIPFS.url('http://en.wikipedia-on-ipfs.org.ipfs.localhost:8080') // false (use .subdomain instead)
 
 isIPFS.path('/ipfs/QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o') // true
+isIPFS.path('/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR?filename=guardian.jpg') // true
 isIPFS.path('/ipns/github.com') // true
 isIPFS.path('/ipfs/js-ipfs/blob/master/README.md') // false
 

--- a/package.json
+++ b/package.json
@@ -42,15 +42,15 @@
   },
   "dependencies": {
     "bs58": "^4.0.1",
-    "cids": "~0.7.0",
+    "cids": "~0.8.0",
     "iso-url": "~0.4.7",
-    "mafmt": "^7.0.0",
-    "multiaddr": "^7.2.1",
+    "mafmt": "^7.1.0",
+    "multiaddr": "^7.4.3",
     "multibase": "~0.7.0",
-    "multihashes": "~0.4.13"
+    "multihashes": "~0.4.19"
   },
   "devDependencies": {
-    "aegir": "^21.4.3",
+    "aegir": "^21.4.5",
     "chai": "^4.2.0",
     "pre-commit": "^1.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -2,16 +2,37 @@
   "name": "is-ipfs",
   "version": "0.6.3",
   "description": "A set of utilities to help identify IPFS resources on the web",
+  "keywords": [
+    "js-ipfs",
+    "ipns",
+    "gateway",
+    "dnslink",
+    "ipfs"
+  ],
+  "homepage": "https://github.com/ipfs/is-ipfs",
+  "bugs": {
+    "url": "https://github.com/ipfs/is-ipfs/issues"
+  },
+  "license": "MIT",
+  "author": "Francisco Dias <francisco@baiodias.com> (http://franciscodias.net/)",
   "leadMaintainer": "Marcin Rataj <lidel@lidel.org>",
+  "files": [
+    "src",
+    "dist"
+  ],
   "main": "src/index.js",
   "browser": {
     "fs": false
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ipfs/is-ipfs.git"
   },
   "scripts": {
     "test:node": "aegir test --target node",
     "test:browser": "aegir test --target browser",
     "test": "aegir test",
-    "lint": "aegir lint",
+    "lint": "aegir lint && aegir lint-package-json",
     "release": "aegir release",
     "release-minor": "aegir release --type minor",
     "release-major": "aegir release --type major",
@@ -19,16 +40,6 @@
     "coverage": "aegir coverage",
     "coverage-publish": "aegir coverage --upload"
   },
-  "pre-commit": [
-    "test",
-    "lint"
-  ],
-  "keywords": [
-    "js-ipfs",
-    "ipfs"
-  ],
-  "author": "Francisco Dias <francisco@baiodias.com> (http://franciscodias.net/)",
-  "license": "MIT",
   "dependencies": {
     "bs58": "^4.0.1",
     "cids": "~0.7.0",
@@ -43,14 +54,14 @@
     "chai": "^4.2.0",
     "pre-commit": "^1.2.2"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ipfs/is-ipfs.git"
+  "engines": {
+    "node": ">=10.0.0",
+    "npm": ">=6.0.0"
   },
-  "bugs": {
-    "url": "https://github.com/ipfs/is-ipfs/issues"
-  },
-  "homepage": "https://github.com/ipfs/is-ipfs",
+  "pre-commit": [
+    "test",
+    "lint"
+  ],
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",
     "David Dias <daviddias.p@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "is-ipfs",
   "version": "0.6.3",
-  "description": "A set of utilities to help identify IPFS resources",
+  "description": "A set of utilities to help identify IPFS resources in URLs and paths",
   "leadMaintainer": "Marcin Rataj <lidel@lidel.org>",
   "main": "src/index.js",
   "browser": {
@@ -34,11 +34,11 @@
     "cids": "~0.7.0",
     "mafmt": "^7.0.0",
     "multiaddr": "^7.2.1",
-    "multibase": "~0.6.0",
+    "multibase": "~0.7.0",
     "multihashes": "~0.4.13"
   },
   "devDependencies": {
-    "aegir": "^20.5.0",
+    "aegir": "^21.4.3",
     "chai": "^4.2.0",
     "pre-commit": "^1.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "bs58": "^4.0.1",
     "cids": "~0.7.0",
+    "iso-url": "~0.4.7",
     "mafmt": "^7.0.0",
     "multiaddr": "^7.2.1",
     "multibase": "~0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "is-ipfs",
   "version": "0.6.3",
-  "description": "A set of utilities to help identify IPFS resources in URLs and paths",
+  "description": "A set of utilities to help identify IPFS resources on the web",
   "leadMaintainer": "Marcin Rataj <lidel@lidel.org>",
   "main": "src/index.js",
   "browser": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ const Multiaddr = require('multiaddr')
 const mafmt = require('mafmt')
 const CID = require('cids')
 
-const urlPattern = /^https?:\/\/[^/]+\/(ip[fn]s)\/([^/]+)/
-const pathPattern = /^\/(ip[fn]s)\/([^/]+)/
+const urlPattern = /^https?:\/\/[^/]+\/(ip[fn]s)\/([^/?#]+)/
+const pathPattern = /^\/(ip[fn]s)\/([^/?#]+)/
 const defaultProtocolMatch = 1
 const defaultHashMath = 2
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const multibase = require('multibase')
 const Multiaddr = require('multiaddr')
 const mafmt = require('mafmt')
 const CID = require('cids')
+const { URL } = require('iso-url')
 
 const pathGatewayPattern = /^https?:\/\/[^/]+\/(ip[fn]s)\/([^/?#]+)/
 const pathPattern = /^\/(ip[fn]s)\/([^/?#]+)/

--- a/test/test-multiaddr.spec.js
+++ b/test/test-multiaddr.spec.js
@@ -67,19 +67,27 @@ describe('ipfs peerMultiaddr', () => {
   // https://github.com/multiformats/js-mafmt/blob/v6.0.6/test/index.spec.js#L137
   const goodCircuit = [
     '/p2p-circuit',
-    '/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
+    '/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj', // /ipfs/ is legacy notation replaced with /p2p/
+    '/p2p-circuit/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
     '/p2p-circuit/ip4/127.0.0.1/tcp/20008/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
+    '/p2p-circuit/ip4/127.0.0.1/tcp/20008/ws/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
     '/p2p-circuit/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
+    '/p2p-circuit/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
+    '/p2p-circuit/ip4/1.2.3.4/tcp/3456/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/p2p-circuit/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/p2p-circuit/ip4/127.0.0.1/tcp/4002/ipfs/QmddWMcQX6orJGHpETYMyPgXrCXCtYANMFVDCvhKoDwLqA',
     '/p2p-circuit/ipfs/QmddWMcQX6orJGHpETYMyPgXrCXCtYANMFVDCvhKoDwLqA',
+    '/p2p-circuit/p2p/QmddWMcQX6orJGHpETYMyPgXrCXCtYANMFVDCvhKoDwLqA',
     '/p2p-circuit/ip4/127.0.0.1/tcp/20008/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj/' +
     'p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj'
   ]
   // https://github.com/multiformats/js-mafmt/blob/v6.0.6/test/index.spec.js#L157
   const validPeerMultiaddrs = [
     '/ip4/127.0.0.1/tcp/20008/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
+    '/ip4/127.0.0.1/tcp/20008/ws/p2p/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj',
+    '/ip4/127.0.0.1/tcp/20008/ws/p2p/12D3KooWFB51PRY9BxcXSH6khFXw1BZeszeLDy7C8GciskqCTZn5', // ed25519+identity multihash
     '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
+    '/ip4/1.2.3.4/tcp/3456/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/ip4/1.2.3.4/tcp/3456/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4',
     '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit',
     '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4/p2p-circuit/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj'

--- a/test/test-path.spec.js
+++ b/test/test-path.spec.js
@@ -7,13 +7,13 @@ const expect = require('chai').expect
 
 describe('ipfs path', () => {
   it('isIPFS.ipfsPath should match an ipfs path', (done) => {
-    const actual = isIPFS.ipfsPath('/ipfs/QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm')
+    const actual = isIPFS.ipfsPath('/ipfs/QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm?arg=val#hash')
     expect(actual).to.equal(true)
     done()
   })
 
   it('isIPFS.ipfsPath should match a complex ipfs path', (done) => {
-    const actual = isIPFS.ipfsPath('/ipfs/QmeWz9YZEeNFXQhHg4PnR5ZiNr5isttgi5n1tc1eD5EfGU/content/index.html')
+    const actual = isIPFS.ipfsPath('/ipfs/QmeWz9YZEeNFXQhHg4PnR5ZiNr5isttgi5n1tc1eD5EfGU/content/index.html?arg=val#hash')
     expect(actual).to.equal(true)
     done()
   })

--- a/test/test-subdomain.spec.js
+++ b/test/test-subdomain.spec.js
@@ -168,23 +168,39 @@ describe('ipfs subdomain', () => {
     done()
   })
 
-  /* We keep subdomain logic separate from legacy urlOrPath checks, below is a fail-safe to ensure we keep that behavior */
-
-  it('isIPFS.urlOrPath should not match ipfs url with cidv1b32 subdomain', (done) => {
+  it('isIPFS.urlOrPath should match ipfs url with cidv1b32 subdomain', (done) => {
     const actual = isIPFS.urlOrPath('http://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.dweb.link')
-    expect(actual).to.equal(false)
+    expect(actual).to.equal(true)
     done()
   })
 
-  it('isIPFS.urlOrPath should not match ipns url', (done) => {
+  it('isIPFS.urlOrPath should match subdomain ipns', (done) => {
     const actual = isIPFS.urlOrPath('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link')
-    expect(actual).to.equal(false)
+    expect(actual).to.equal(true)
     done()
   })
 
-  it('isIPFS.urlOrPath should not match ipns in subdomain', (done) => {
-    const actual = isIPFS.urlOrPath('http://a-dnslink-website.com.ipns.dweb.link')
-    expect(actual).to.equal(false)
+  it('isIPFS.urlOrPath should match potential DNSLink in subdomain', (done) => {
+    const actual = isIPFS.urlOrPath('http://a-dnslink-website.com.ipns.localhost:8080')
+    expect(actual).to.equal(true)
+    done()
+  })
+
+  it('isIPFS.url should match ipfs url with cidv1b32 subdomain', (done) => {
+    const actual = isIPFS.url('http://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.dweb.link')
+    expect(actual).to.equal(true)
+    done()
+  })
+
+  it('isIPFS.url should match subdomain ipns', (done) => {
+    const actual = isIPFS.url('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link')
+    expect(actual).to.equal(true)
+    done()
+  })
+
+  it('isIPFS.url should match potential DNSLink in subdomain', (done) => {
+    const actual = isIPFS.url('http://a-dnslink-website.com.ipns.localhost:8080')
+    expect(actual).to.equal(true)
     done()
   })
 })

--- a/test/test-subdomain.spec.js
+++ b/test/test-subdomain.spec.js
@@ -74,13 +74,6 @@ describe('ipfs subdomain', () => {
     done()
   })
 
-  it('isIPFS.ipnsSubdomain should not match .ipns. zone with non-cid subdomain', (done) => {
-    // we do not support opaque strings in subdomains, only  peerids
-    const actual = isIPFS.ipnsSubdomain('http://a-dnslink-website.com.ipns.dweb.link')
-    expect(actual).to.equal(false)
-    done()
-  })
-
   it('isIPFS.ipnsSubdomain should not match without .ipns. zone', (done) => {
     const actual = isIPFS.ipnsSubdomain('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.dweb.link')
     expect(actual).to.equal(false)
@@ -93,34 +86,32 @@ describe('ipfs subdomain', () => {
     done()
   })
 
-  it('isIPFS.dnslinkSubdomain should match .ipns.localhost zone with FQDN', (done) => {
-    // we do not support opaque strings in subdomains, only  peerids
-    const actual = isIPFS.dnslinkSubdomain('http://docs.ipfs.io.ipns.localhost:8080/some/path')
+  it('isIPFS.ipnsSubdomain should match .ipns.localhost zone with FQDN', (done) => {
+    const actual = isIPFS.ipnsSubdomain('http://docs.ipfs.io.ipns.localhost:8080/some/path')
     expect(actual).to.equal(true)
     done()
   })
 
-  it('isIPFS.dnslinkSubdomain should match .ipns.sub.sub.domain.tld zone with FQDN', (done) => {
-    // we do not support opaque strings in subdomains, only  peerids
-    const actual = isIPFS.dnslinkSubdomain('http://docs.ipfs.io.ipns.foo.bar.buzz.dweb.link')
+  it('isIPFS.ipnsSubdomain should match .ipns.sub.sub.domain.tld zone with FQDN', (done) => {
+    const actual = isIPFS.ipnsSubdomain('http://docs.ipfs.io.ipns.foo.bar.buzz.dweb.link')
     expect(actual).to.equal(true)
     done()
   })
 
-  it('isIPFS.dnslinkSubdomain should match *.ipns. zone with FQDN', (done) => {
-    const actual = isIPFS.dnslinkSubdomain('http://docs.ipfs.io.ipns.locahost:8080')
+  it('isIPFS.ipnsSubdomain should match *.ipns. zone with FQDN', (done) => {
+    const actual = isIPFS.ipnsSubdomain('http://docs.ipfs.io.ipns.locahost:8080')
     expect(actual).to.equal(true)
     done()
   })
 
-  it('isIPFS.dnslinkSubdomain should not match a .ipns. zone with cidv1b32', (done) => {
-    const actual = isIPFS.dnslinkSubdomain('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link')
-    expect(actual).to.equal(false)
+  it('isIPFS.ipnsSubdomain should match .ipns. zone with cidv1b32', (done) => {
+    const actual = isIPFS.ipnsSubdomain('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link')
+    expect(actual).to.equal(true)
     done()
   })
 
-  it('isIPFS.dnslinkSubdomain should not match if *.ipns is not a fqdn with tld', (done) => {
-    const actual = isIPFS.dnslinkSubdomain('http://no-fqdn-with-tld.ipns.dweb.link')
+  it('isIPFS.ipnsSubdomain should not match if *.ipns is not a fqdn with tld', (done) => {
+    const actual = isIPFS.ipnsSubdomain('http://no-fqdn-with-tld.ipns.dweb.link')
     expect(actual).to.equal(false)
     done()
   })

--- a/test/test-subdomain.spec.js
+++ b/test/test-subdomain.spec.js
@@ -18,6 +18,12 @@ describe('ipfs subdomain', () => {
     done()
   })
 
+  it('isIPFS.ipfsSubdomain should match localhost with port', (done) => {
+    const actual = isIPFS.ipfsSubdomain('http://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.localhost:8080')
+    expect(actual).to.equal(true)
+    done()
+  })
+
   it('isIPFS.ipfsSubdomain should not match non-cid subdomains', (done) => {
     const actual = isIPFS.ipfsSubdomain('http://not-a-cid.ipfs.dweb.link')
     expect(actual).to.equal(false)
@@ -87,6 +93,32 @@ describe('ipfs subdomain', () => {
     done()
   })
 
+  it('isIPFS.dnslinkSubdomain should match .ipns.localhost zone with FQDN', (done) => {
+    // we do not support opaque strings in subdomains, only  peerids
+    const actual = isIPFS.dnslinkSubdomain('http://docs.ipfs.io.ipns.localhost:8080/some/path')
+    expect(actual).to.equal(true)
+    done()
+  })
+
+  it('isIPFS.dnslinkSubdomain should match .ipns.sub.sub.domain.tld zone with FQDN', (done) => {
+    // we do not support opaque strings in subdomains, only  peerids
+    const actual = isIPFS.dnslinkSubdomain('http://docs.ipfs.io.ipns.foo.bar.buzz.dweb.link')
+    expect(actual).to.equal(true)
+    done()
+  })
+
+  it('isIPFS.dnslinkSubdomain should match *.ipns. zone with FQDN', (done) => {
+    const actual = isIPFS.dnslinkSubdomain('http://docs.ipfs.io.ipns.locahost:8080')
+    expect(actual).to.equal(true)
+    done()
+  })
+
+  it('isIPFS.dnslinkSubdomain should not match a .ipns. zone with cidv1b32', (done) => {
+    const actual = isIPFS.dnslinkSubdomain('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link')
+    expect(actual).to.equal(false)
+    done()
+  })
+
   it('isIPFS.subdomain should match an ipfs subdomain', (done) => {
     const actual = isIPFS.subdomain('http://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.dweb.link')
     expect(actual).to.equal(true)
@@ -95,6 +127,13 @@ describe('ipfs subdomain', () => {
 
   it('isIPFS.subdomain should match an ipns subdomain with PeerID as cidv1b32', (done) => {
     const actual = isIPFS.subdomain('http://bafybeiabc2xofh6tdi6vutusorpumwcikw3hf3st4ecjugo6j52f6xwc6q.ipns.dweb.link')
+    expect(actual).to.equal(true)
+    done()
+  })
+
+  it('isIPFS.subdomain should match .ipns.localhost zone with FQDN', (done) => {
+    // we do not support opaque strings in subdomains, only  peerids
+    const actual = isIPFS.subdomain('http://docs.ipfs.io.ipns.dweb.link')
     expect(actual).to.equal(true)
     done()
   })

--- a/test/test-subdomain.spec.js
+++ b/test/test-subdomain.spec.js
@@ -119,6 +119,12 @@ describe('ipfs subdomain', () => {
     done()
   })
 
+  it('isIPFS.dnslinkSubdomain should not match if *.ipns is not a fqdn with tld', (done) => {
+    const actual = isIPFS.dnslinkSubdomain('http://no-fqdn-with-tld.ipns.dweb.link')
+    expect(actual).to.equal(false)
+    done()
+  })
+
   it('isIPFS.subdomain should match an ipfs subdomain', (done) => {
     const actual = isIPFS.subdomain('http://bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27fclha2va.ipfs.dweb.link')
     expect(actual).to.equal(true)
@@ -150,8 +156,8 @@ describe('ipfs subdomain', () => {
     done()
   })
 
-  it('isIPFS.subdomain should not match if ipns peerid is invalid', (done) => {
-    const actual = isIPFS.subdomain('http://not-a-cid.ipns.dweb.link')
+  it('isIPFS.subdomain should not match if *.ipns is not libp2pkey nor fqdn', (done) => {
+    const actual = isIPFS.subdomain('http://not-a-cid-or-dnslink.ipns.dweb.link')
     expect(actual).to.equal(false)
     done()
   })

--- a/test/test-url.spec.js
+++ b/test/test-url.spec.js
@@ -7,13 +7,13 @@ const isIPFS = require('../src/index')
 
 describe('ipfs url', () => {
   it('isIPFS.ipfsUrl should match an ipfs url', (done) => {
-    const actual = isIPFS.ipfsUrl('http://ipfs.io/ipfs/QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm')
+    const actual = isIPFS.ipfsUrl('http://ipfs.io/ipfs/QmYHNYAaYK5hm3ZhZFx5W9H6xydKDGimjdgJMrMSdnctEm?arg=val#hash')
     expect(actual).to.equal(true)
     done()
   })
 
   it('isIPFS.ipfsUrl should match a complex ipfs url', (done) => {
-    const actual = isIPFS.ipfsUrl('http://ipfs.alexandria.media/ipfs/QmeWz9YZEeNFXQhHg4PnR5ZiNr5isttgi5n1tc1eD5EfGU/content/index.html')
+    const actual = isIPFS.ipfsUrl('http://ipfs.alexandria.media/ipfs/QmeWz9YZEeNFXQhHg4PnR5ZiNr5isttgi5n1tc1eD5EfGU/content/index.html?arg=val#hash')
     expect(actual).to.equal(true)
     done()
   })


### PR DESCRIPTION
This PR updates  `isIPFS.url(url)` to return true if `isIPFS.subdomain(url)` does,
and improves  `isIPFS.ipnsSubdomain(url)` to match potential DNSLink just like `isIPFS.ipnsPath(url)` already did.

This is needed for https://github.com/ipfs-shipyard/ipfs-companion/pull/853:

## BREAKING CHANGES

- BREAKING CHANGE: `isIPFS.subdomain` now returns true for `<domain.tld>.ipns.localhost`
- BREAKING CHANGE: `isIPFS.subdomainPattern|pathPattern|urlPattern` are replaced with `pathPattern|pathGatewayPattern|subdomainGatewayPattern`
- BREAKING CHANGE: `isIPFS.url` now returns true if `isIPFS.subdomain` did

Due to this I plan to release this as v1.0.0